### PR TITLE
feat: Added a ServerCommand to list tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +92,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "gimli"
@@ -166,6 +184,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +261,32 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -362,10 +432,17 @@ dependencies = [
  "connection",
  "daemonize",
  "libc 0.1.0",
+ "mockall",
  "serde",
  "serde_yaml",
  "tokio",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ commands = { path = "./crates/commands" }
 tokio = { version = "1.43.0", features = ["full"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_yaml = "0.9.34"
+mockall = "0.13.1"

--- a/crates/commands/src/client_commands.rs
+++ b/crates/commands/src/client_commands.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ClientCommands {
     SuccessfulConnection,
     FailedToParseFrame,
-    Test, // TODO delete me
+
+    TaskList(String),
 }

--- a/crates/commands/src/server_commands.rs
+++ b/crates/commands/src/server_commands.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ServerCommands {
-    Test, // TODO delete me
+    ListTasks,
 }

--- a/src/task_server/client_handler/commands/list_tasks.rs
+++ b/src/task_server/client_handler/commands/list_tasks.rs
@@ -36,7 +36,7 @@ mod test {
             .once()
             .return_once(|| "List of tasks".to_string());
 
-        let mut client = client_handler::test_utils::setup_test(mock_task_manager).await;
+        let (mut client, server) = client_handler::test_utils::setup_test(mock_task_manager).await;
 
         client
             .write_frame(&ServerCommands::ListTasks)
@@ -47,5 +47,7 @@ mod test {
             frame,
             Some(ClientCommands::TaskList("List of tasks".to_string()))
         );
+
+        server.check_errors(client).await;
     }
 }

--- a/src/task_server/client_handler/commands/list_tasks.rs
+++ b/src/task_server/client_handler/commands/list_tasks.rs
@@ -1,0 +1,51 @@
+use commands::ClientCommands;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::task_server::{
+    client_handler::{ClientHandler, Result},
+    task_manager::TaskManagerTrait,
+};
+
+impl<Stream, TaskManager> ClientHandler<Stream, TaskManager>
+where
+    Stream: AsyncWrite + AsyncRead + Unpin,
+    TaskManager: TaskManagerTrait,
+{
+    pub(in super::super) async fn handle_list_tasks(&mut self) -> Result<()> {
+        eprintln!("Client {} requested ListTasks", self.client_id);
+
+        let task_list = self.task_manager.lock().await.list_tasks();
+        let response = ClientCommands::TaskList(task_list);
+
+        eprintln!("Client {} ListTasks response: {response:?}", self.client_id);
+        self.write_frame(&response).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use commands::{ClientCommands, ServerCommands};
+
+    use crate::task_server::{client_handler, task_manager::MockTaskManagerTrait};
+
+    #[tokio::test]
+    async fn test_handle_list_tasks() {
+        let mut mock_task_manager = MockTaskManagerTrait::new();
+        mock_task_manager
+            .expect_list_tasks()
+            .once()
+            .return_once(|| "List of tasks".to_string());
+
+        let mut client = client_handler::test_utils::setup_test(mock_task_manager).await;
+
+        client
+            .write_frame(&ServerCommands::ListTasks)
+            .await
+            .unwrap();
+        let frame = client.read_frame().await.unwrap();
+        assert_eq!(
+            frame,
+            Some(ClientCommands::TaskList("List of tasks".to_string()))
+        );
+    }
+}

--- a/src/task_server/client_handler/commands/mod.rs
+++ b/src/task_server/client_handler/commands/mod.rs
@@ -1,0 +1,1 @@
+mod list_tasks;

--- a/src/task_server/client_handler/mod.rs
+++ b/src/task_server/client_handler/mod.rs
@@ -3,3 +3,9 @@ mod client_handler;
 pub use client_handler::ClientHandler;
 
 mod error;
+pub use error::{Error, Result};
+
+mod commands;
+
+#[cfg(test)]
+mod test_utils;

--- a/src/task_server/client_handler/test_utils.rs
+++ b/src/task_server/client_handler/test_utils.rs
@@ -1,28 +1,52 @@
-use std::sync::Arc;
+use std::{mem::ManuallyDrop, sync::Arc};
 
 use commands::{ClientCommands, ServerCommands};
 use connection::Connection;
-use tokio::{io::DuplexStream, sync::Mutex};
+use tokio::{io::DuplexStream, sync::Mutex, task::JoinHandle};
 
 use crate::task_server::{client_handler::ClientHandler, task_manager::MockTaskManagerTrait};
 
-pub async fn setup_test(
-    task_manager: MockTaskManagerTrait,
-) -> Connection<DuplexStream, ClientCommands, ServerCommands> {
-    let task_manager = Arc::new(Mutex::new(task_manager));
+type TestConnection = Connection<DuplexStream, ClientCommands, ServerCommands>;
 
+pub struct TestServer {
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl TestServer {
+    fn new(server: DuplexStream, task_manager: MockTaskManagerTrait) -> Self {
+        let task_manager = Arc::new(Mutex::new(task_manager));
+
+        Self {
+            join_handle: Some(tokio::spawn(async move {
+                ClientHandler::process_client(server, task_manager)
+                    .await
+                    .unwrap();
+            })),
+        }
+    }
+
+    pub async fn check_errors(mut self, client: TestConnection) {
+        drop(client);
+        self.join_handle.take().unwrap().await.unwrap();
+        let _ = ManuallyDrop::new(self);
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        panic!("TestServer::check_errors() was not called");
+    }
+}
+
+pub async fn setup_test(task_manager: MockTaskManagerTrait) -> (TestConnection, TestServer) {
     let (client, server) = tokio::io::duplex(4096);
 
-    let mut client = Connection::new(client, 4096);
+    let mut client = TestConnection::new(client, 4096);
 
-    tokio::spawn(async move {
-        ClientHandler::process_client(server, task_manager)
-            .await
-            .unwrap();
-    });
+    let server = TestServer::new(server, task_manager);
 
     let frame = client.read_frame().await.unwrap();
     assert_eq!(frame, Some(ClientCommands::SuccessfulConnection));
 
-    client
+    (client, server)
 }

--- a/src/task_server/client_handler/test_utils.rs
+++ b/src/task_server/client_handler/test_utils.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use commands::{ClientCommands, ServerCommands};
+use connection::Connection;
+use tokio::{io::DuplexStream, sync::Mutex};
+
+use crate::task_server::{client_handler::ClientHandler, task_manager::MockTaskManagerTrait};
+
+pub async fn setup_test(
+    task_manager: MockTaskManagerTrait,
+) -> Connection<DuplexStream, ClientCommands, ServerCommands> {
+    let task_manager = Arc::new(Mutex::new(task_manager));
+
+    let (client, server) = tokio::io::duplex(4096);
+
+    let mut client = Connection::new(client, 4096);
+
+    tokio::spawn(async move {
+        ClientHandler::process_client(server, task_manager)
+            .await
+            .unwrap();
+    });
+
+    let frame = client.read_frame().await.unwrap();
+    assert_eq!(frame, Some(ClientCommands::SuccessfulConnection));
+
+    client
+}

--- a/src/task_server/mod.rs
+++ b/src/task_server/mod.rs
@@ -6,3 +6,4 @@ mod error;
 pub use error::Error;
 
 mod client_handler;
+mod task_manager;

--- a/src/task_server/task_manager.rs
+++ b/src/task_server/task_manager.rs
@@ -1,0 +1,36 @@
+use std::fmt::Display;
+
+use mockall::automock;
+
+use crate::parser::program::Program;
+
+pub struct TaskManager {
+    pub tasks: Vec<Program>,
+}
+
+impl TaskManager {
+    pub fn new(tasks: Vec<Program>) -> Self {
+        Self { tasks }
+    }
+}
+
+#[automock]
+pub trait TaskManagerTrait {
+    fn list_tasks(&self) -> String;
+}
+
+impl TaskManagerTrait for TaskManager {
+    fn list_tasks(&self) -> String {
+        println!("{:<15}{:^50}{:10}", "program name", "cmd", "pids");
+        self.tasks
+            .iter()
+            .fold(String::new(), |acc, value| format!("{acc}{}\n", value))
+    }
+}
+
+impl Display for TaskManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let tasks: Vec<String> = self.tasks.iter().map(|value| format!("{value}")).collect();
+        write!(f, "{}", tasks.join("\n"))
+    }
+}

--- a/src/task_server/task_server.rs
+++ b/src/task_server/task_server.rs
@@ -1,22 +1,26 @@
-use std::fmt::Display;
+use std::sync::Arc;
 
-use tokio::net::{TcpListener, ToSocketAddrs};
+use tokio::{
+    net::{TcpListener, ToSocketAddrs},
+    sync::Mutex,
+};
 
 use super::{
     client_handler::ClientHandler,
     error::{Error, Result},
+    task_manager::TaskManager,
 };
 use crate::Program;
 
 pub struct TaskServer {
-    tasks: Vec<Program>,
+    task_manager: Arc<Mutex<TaskManager>>,
     listener: TcpListener,
 }
 
 impl TaskServer {
     pub async fn new(tasks: Vec<Program>, addr: impl ToSocketAddrs + Into<String>) -> Result<Self> {
         Ok(Self {
-            tasks,
+            task_manager: Arc::new(Mutex::new(TaskManager::new(tasks))),
             listener: TcpListener::bind(&addr).await.map_err(|error| {
                 Error::FailedToBindTcpListener {
                     addr: addr.into(),
@@ -29,25 +33,12 @@ impl TaskServer {
     pub async fn run(self) {
         loop {
             let (socket, _) = self.listener.accept().await.unwrap();
+            let task_manager = Arc::clone(&self.task_manager);
             tokio::spawn(async move {
-                ClientHandler::process_client(socket)
+                ClientHandler::process_client(socket, task_manager)
                     .await
                     .inspect_err(|err| eprintln!("ClientHandler error: {err:?}"))
             });
         }
-    }
-
-    pub fn _list_tasks(&self) -> String {
-        println!("{:<15}{:^50}{:10}", "program name", "cmd", "pids");
-        self.tasks
-            .iter()
-            .fold(String::new(), |acc, value| format!("{acc}{}\n", value))
-    }
-}
-
-impl Display for TaskServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let tasks: Vec<String> = self.tasks.iter().map(|value| format!("{value}")).collect();
-        write!(f, "{}", tasks.join("\n"))
     }
 }


### PR DESCRIPTION
Created TaskManager to hold the server's state.
An Arc<Mutex<TaskManager>> is passed to the ClientHandlers so that the clients can call TaskManager methods.

Also added the mockall crate to test the different commands easily.