### PR TITLE
29  Refactored process status handling

### DIFF
--- a/taskmaster/src/process_handler/status.rs
+++ b/taskmaster/src/process_handler/status.rs
@@ -1,17 +1,11 @@
 use std::process::ExitStatus;
 
 #[allow(dead_code)]
-#[derive(Clone)]
 pub enum Status {
     NotSpawned,
     Starting,
     Running,
-    FailedToInit {
-        error_message: String,
-        exit_code: u8,
-    },
-    FailedToSpawn {
-        error_message: String,
-    },
+    ErrorDuringStartup { exit_code: u8 },
+    FailedToSpawn(tokio::io::Error),
     Exited(ExitStatus),
 }

--- a/taskmaster/src/process_handler/tests.rs
+++ b/taskmaster/src/process_handler/tests.rs
@@ -15,8 +15,12 @@ async fn get_status(
                     Status::NotSpawned => println!("Status: NotSpawned"),
                     Status::Starting => println!("Status: Starting"),
                     Status::Running => println!("Status: Running"),
-                    Status::FailedToInit { error_message, exit_code: _ } => println!("Status: FailedToInit: {error_message}"),
-                    Status::FailedToSpawn { error_message} => println!("Status: FailedToSpawn: {error_message}"),
+                    Status::ErrorDuringStartup { exit_code } => {
+                        println!("Status: ErrorDuringStartup: exit code: {exit_code}")
+                    },
+                    Status::FailedToSpawn(error) => {
+                        println!("Status: FailedToSpawn: {error}")
+                    },
                     Status::Exited(_) => {
                         println!("Status: Exited");
                         break;


### PR DESCRIPTION
- Removed `Clone` requirement from the `Status` struct

- Renamed `status()` fn to `send_new_status_to_task_manager()`

- Removed the strings from `Status::ErrorDuringStartup` and `Status::FailedToSpawn`