### PR TITLE
refactor: changed place for task manager routine

### DIFF
--- a/taskmaster/src/config/mod.rs
+++ b/taskmaster/src/config/mod.rs
@@ -8,11 +8,12 @@ use serde::Deserialize;
 use serde::de::Error;
 use std::collections::HashMap;
 use std::fs::File;
+use std::sync::Arc;
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Config {
-    pub programs: Vec<ProgramConfig>,
+    pub programs: HashMap<String, Arc<ProgramConfig>>,
 }
 
 #[derive(Deserialize)]
@@ -23,7 +24,7 @@ struct TmpConfig {
 }
 
 impl TmpConfig {
-    fn programs(self) -> Result<Vec<ProgramConfig>, serde_yaml::Error> {
+    fn programs(self) -> Result<HashMap<String, ProgramConfig>, serde_yaml::Error> {
         self.programs
             .into_iter()
             .map(|(name, mut program)| {
@@ -34,8 +35,8 @@ impl TmpConfig {
                     )));
                 }
 
-                *program.name_mut() = name;
-                Ok(program)
+                *program.name_mut() = name.clone();
+                Ok((name, program))
             })
             .collect()
     }
@@ -45,7 +46,11 @@ impl Config {
     pub fn from_reader(file: impl std::io::Read) -> Result<Config, serde_yaml::Error> {
         let tmp_config: TmpConfig = serde_yaml::from_reader(file)?;
         let config = Self {
-            programs: tmp_config.programs()?,
+            programs: tmp_config
+                .programs()?
+                .into_iter()
+                .map(|(name, program)| (name, Arc::new(program)))
+                .collect(),
         };
         Ok(config)
     }

--- a/taskmaster/src/config/program.rs
+++ b/taskmaster/src/config/program.rs
@@ -216,6 +216,7 @@ mod tests {
     use std::collections::HashMap;
     use std::io::Cursor;
     use std::str::FromStr;
+    use std::sync::Arc;
 
     fn yaml_from_string_command(command: &str) -> String {
         let start = r#"programs:
@@ -302,9 +303,9 @@ mod tests {
     }
 
     fn assert_config_parses_to(yaml_content: &str, expected_program: ProgramConfig) {
-        let expected_config = Config {
-            programs: vec![expected_program],
-        };
+        let mut programs = HashMap::new();
+        programs.insert(expected_program.name.clone(), Arc::new(expected_program));
+        let expected_config = Config { programs };
 
         let config_reader = Cursor::new(yaml_content);
         let parsed_config = Config::from_reader(config_reader);

--- a/taskmaster/src/main.rs
+++ b/taskmaster/src/main.rs
@@ -6,7 +6,7 @@ mod tasks_manager;
 use crate::tasks_manager::ServerCommandError;
 use config::{Config, ProgramConfig};
 use error::Error;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tasks_manager::TaskManagerCommand;
 use tokio::sync::{mpsc, oneshot};
 
@@ -34,17 +34,12 @@ fn entrypoint() -> Result<(), Error> {
     let Args { port } = parse_args(std::env::args().nth(1))?;
 
     let tasks = get_tasks_from_config("taskmaster.yaml");
-    let tasks = convert_tasks_to_arc(tasks);
 
     if !cfg!(debug_assertions) {
         daemonize()?
     }
 
     start_server(port, tasks)
-}
-
-pub fn convert_tasks_to_arc(programs: Vec<ProgramConfig>) -> Vec<Arc<ProgramConfig>> {
-    programs.into_iter().map(Arc::new).collect()
 }
 
 fn parse_args(port: Option<String>) -> Result<Args, Error> {
@@ -83,12 +78,12 @@ mod taskmaster {
     }
 }
 
-fn get_tasks_from_config(config_file: &str) -> Vec<ProgramConfig> {
+fn get_tasks_from_config(config_file: &str) -> HashMap<String, Arc<ProgramConfig>> {
     match Config::parse(config_file) {
         Ok(config) => config.programs,
         Err(err) => {
             eprintln!("Warning {err}"); //TODO: log error and/or broadcast to clients
-            Vec::new()
+            HashMap::new()
         }
     }
 }
@@ -103,7 +98,7 @@ fn daemonize() -> Result<(), Error> {
     Ok(())
 }
 
-fn start_server(_port: i32, _tasks: Vec<Arc<ProgramConfig>>) -> Result<(), Error> {
+fn start_server(_port: i32, _tasks: HashMap<String, Arc<ProgramConfig>>) -> Result<(), Error> {
     tokio::runtime::Runtime::new()
         .expect("Failed to init tokio runtime")
         .block_on(async { Result::<(), Error>::Ok(()) })

--- a/taskmaster/src/process_handler/tests.rs
+++ b/taskmaster/src/process_handler/tests.rs
@@ -96,20 +96,15 @@ async fn create_task() {
         .programs
         .into_iter()
         .next()
-        .expect("Config vector is empty");
+        .expect("Config vector is empty")
+        .1;
 
     let (status_sender, status_receiver) = mpsc::unbounded_channel();
     let (log_sender, log_receiver) = mpsc::unbounded_channel();
     let name = format!("{}-0", program.name());
-    let routine_handle = Routine::spawn(
-        Arc::new(program),
-        status_sender,
-        log_sender,
-        name.clone(),
-        0,
-    )
-    .await
-    .expect("failed to spawn tokio::task");
+    let routine_handle = Routine::spawn(program, status_sender, log_sender, name.clone(), 0)
+        .await
+        .expect("failed to spawn tokio::task");
     let log_checker_handle = tokio::spawn(check_realtime_output(log_receiver));
     let status_receiver = Arc::new(Mutex::new(status_receiver));
     let status_checker_handle =
@@ -189,15 +184,15 @@ async fn create_task_then_interrupt() {
         .programs
         .into_iter()
         .next()
-        .expect("Config vector is empty");
+        .expect("Config hashmap is empty")
+        .1;
 
     let (status_sender, status_receiver) = mpsc::unbounded_channel();
     let (log_sender, _) = mpsc::unbounded_channel();
     let name = format!("{}-0", config.name());
-    let routine_handle =
-        Routine::spawn(Arc::new(config), status_sender, log_sender, name.clone(), 0)
-            .await
-            .expect("failed to spawn tokio::task");
+    let routine_handle = Routine::spawn(config, status_sender, log_sender, name.clone(), 0)
+        .await
+        .expect("failed to spawn tokio::task");
     let status_receiver: Arc<Mutex<UnboundedReceiver<NominativeStatus>>> =
         Arc::new(Mutex::new(status_receiver));
     let handle2 = tokio::spawn(check_status(Arc::clone(&status_receiver), name.clone()));

--- a/taskmaster/src/tasks_manager/mod.rs
+++ b/taskmaster/src/tasks_manager/mod.rs
@@ -1,6 +1,8 @@
 mod handle;
 mod process;
 mod routine;
+
+#[cfg(test)]
 mod tests;
 
 use crate::process_handler::NominativeStatus;

--- a/taskmaster/src/tasks_manager/routine/handle_command.rs
+++ b/taskmaster/src/tasks_manager/routine/handle_command.rs
@@ -31,7 +31,6 @@ impl Routine {
             }
 
             TaskManagerCommand::StopProgram { program_name } => {
-                println!("{}", program_name);
                 self.stop_program(program_name).await?
             }
 

--- a/taskmaster/src/tasks_manager/routine/handle_command.rs
+++ b/taskmaster/src/tasks_manager/routine/handle_command.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use crate::{
+    config::ProgramConfig,
+    process_handler::NominativeStatus,
+    tasks_manager::{
+        ServerCommandError, TaskManagerCommand,
+        routine::{Client, Routine},
+    },
+};
+
+impl Routine {
+    pub async fn handle_command(
+        &mut self,
+        command: TaskManagerCommand,
+    ) -> Result<(), ServerCommandError> {
+        match command {
+            TaskManagerCommand::ListProcesses(list_sender) => {
+                list_sender
+                    .send(self.list_processes().await)
+                    .expect("Receiver should never be dropped");
+            }
+
+            TaskManagerCommand::StartProgram { program_name } => {
+                self.handle_start_program_command(program_name).await?
+            }
+
+            TaskManagerCommand::RestartProgram { program_name } => {
+                self.stop_program(&program_name).await?;
+                self.handle_start_program_command(program_name).await?
+            }
+
+            TaskManagerCommand::StopProgram { program_name } => {
+                println!("{}", program_name);
+                self.stop_program(program_name).await?
+            }
+
+            TaskManagerCommand::SubscribeToProgramEvents {
+                program_name,
+                client,
+            } => {
+                self.handle_subscribe_to_program_events(program_name, client)
+                    .await?
+            }
+
+            TaskManagerCommand::UnsubscribeToProgramEvents {
+                program_name,
+                client,
+            } => {
+                self.handle_unsubscribe_to_program_events(program_name, client)
+                    .await?
+            }
+
+            TaskManagerCommand::StopAllProcesses => self.stop_all_processes().await,
+
+            TaskManagerCommand::Exit => {
+                panic!("Exit command should be handled by Routine::event_listener")
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_start_program_command(
+        &mut self,
+        program_name: String,
+    ) -> Result<(), ServerCommandError> {
+        let program_config = self
+            .get_program_config(program_name.as_str())
+            .ok_or(super::ServerCommandError::NoSuchProgram(program_name))?;
+        self.start_program(&program_config).await;
+        Ok(())
+    }
+
+    async fn handle_subscribe_to_program_events(
+        &mut self,
+        program_name: String,
+        client: Client,
+    ) -> Result<(), ServerCommandError> {
+        self.clients
+            .lock()
+            .await
+            .get(&program_name)
+            .ok_or(super::ServerCommandError::NoSuchProgram(program_name))?
+            .add(client);
+        Ok(())
+    }
+
+    async fn handle_unsubscribe_to_program_events(
+        &mut self,
+        program_name: String,
+        client: Client,
+    ) -> Result<(), ServerCommandError> {
+        self.clients
+            .lock()
+            .await
+            .get(&program_name)
+            .ok_or(super::ServerCommandError::NoSuchProgram(program_name))?
+            .remove(client);
+        Ok(())
+    }
+
+    async fn list_processes(&self) -> Vec<Vec<NominativeStatus>> {
+        self.processes
+            .lock()
+            .await
+            .iter()
+            .map(|(name, processes)| {
+                processes
+                    .iter()
+                    .enumerate()
+                    .map(|(id, process)| NominativeStatus {
+                        process_name: format!("{}-{}", name, id),
+                        status: process.status.clone(),
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    async fn stop_program(
+        &mut self,
+        program_name: impl AsRef<str> + Into<String>,
+    ) -> Result<(), ServerCommandError> {
+        let mut processes = self.processes.lock().await;
+
+        for process in processes
+            .get_mut(program_name.as_ref())
+            .ok_or_else(|| ServerCommandError::NoSuchProgram(program_name.into()))?
+            .iter_mut()
+        {
+            process.stop_and_join_if_running().await;
+        }
+        Ok(())
+    }
+
+    fn get_program_config(&self, program_name: &str) -> Option<Arc<ProgramConfig>> {
+        self.program_configs.get(program_name).map(Arc::clone)
+    }
+}

--- a/taskmaster/src/tasks_manager/routine/mod.rs
+++ b/taskmaster/src/tasks_manager/routine/mod.rs
@@ -99,7 +99,12 @@ impl Routine {
     async fn start_process(&mut self, process_id: usize, program_config: Arc<ProgramConfig>) {
         let process_name = format!("{}-{}", program_config.name(), process_id);
 
-        match self.processes.lock().await.entry(program_config.name().clone()) {
+        match self
+            .processes
+            .lock()
+            .await
+            .entry(program_config.name().clone())
+        {
             hash_map::Entry::Occupied(mut entry) => {
                 if !entry.get()[process_id].is_async_task_running() {
                     let process_generation =

--- a/taskmaster/src/tasks_manager/routine/mod.rs
+++ b/taskmaster/src/tasks_manager/routine/mod.rs
@@ -1,8 +1,11 @@
+mod handle_command;
+
 use super::Process;
 use super::TaskManagerCommand;
 use super::handle::Handle;
 use crate::CommandReceiver;
 use crate::process_handler::NominativeStatus;
+use crate::tasks_manager::ServerCommandError;
 use crate::{
     config::ProgramConfig,
     process_handler::{self, LogReceiver, LogSender, Status, StatusReceiver},
@@ -33,7 +36,7 @@ impl SubscribedClients {
 
 #[allow(dead_code)] //TODO: Remove that
 pub struct Routine {
-    program_configs: Arc<Vec<Arc<ProgramConfig>>>,
+    program_configs: Arc<HashMap<String, Arc<ProgramConfig>>>,
     clients: ClientMap,
     processes: Arc<Mutex<HashMap<String, Vec<Process>>>>,
     command_receiver: CommandReceiver,
@@ -43,14 +46,14 @@ pub struct Routine {
 
 #[allow(dead_code)] //TODO: remove that
 impl Routine {
-    pub fn spawn(program_configs: Vec<Arc<ProgramConfig>>) -> Handle {
+    pub fn spawn(program_configs: HashMap<String, Arc<ProgramConfig>>) -> Handle {
         let (log_sender, log_receiver) = mpsc::unbounded_channel();
         let (status_sender, status_receiver) = mpsc::unbounded_channel();
         let (command_sender, command_receiver) = mpsc::unbounded_channel();
 
         let handle = tokio::spawn(async move {
             Self {
-                program_configs: program_configs.into(),
+                program_configs: Arc::new(program_configs),
                 processes: Arc::new(Mutex::new(HashMap::new())),
                 clients: Arc::new(Mutex::new(HashMap::new())),
                 command_receiver,
@@ -79,7 +82,7 @@ impl Routine {
     }
 
     async fn start_programs(&mut self) {
-        for program_config in Arc::clone(&self.program_configs).iter() {
+        for (_, program_config) in Arc::clone(&self.program_configs).iter() {
             self.start_program(program_config).await;
         }
     }
@@ -96,7 +99,7 @@ impl Routine {
     async fn start_process(&mut self, process_id: usize, program_config: Arc<ProgramConfig>) {
         let process_name = format!("{}-{}", program_config.name(), process_id);
 
-        match self.processes.lock().await.entry(process_name.clone()) {
+        match self.processes.lock().await.entry(program_config.name().clone()) {
             hash_map::Entry::Occupied(mut entry) => {
                 if !entry.get()[process_id].is_async_task_running() {
                     let process_generation =
@@ -151,6 +154,14 @@ impl Routine {
         Some((program_name, id))
     }
 
+    fn get_program_name(process_name: &str) -> Option<String> {
+        if let Some((program_name, _)) = Self::split_process_name(process_name.to_string()) {
+            Some(program_name)
+        } else {
+            None
+        }
+    }
+
     async fn listen_for_status(
         mut status_receiver: StatusReceiver,
         processes: Arc<Mutex<HashMap<String, Vec<Process>>>>,
@@ -175,11 +186,11 @@ impl Routine {
     /// logs are already written to log files, we only need to write them to the client if he asks for it
     async fn listen_for_logs(mut log_receiver: LogReceiver, clients: ClientMap) {
         while let Some(log) = log_receiver.recv().await {
-            let index = log
-                .process_name
-                .rfind('-')
-                .unwrap_or(log.process_name.len());
-            if let Some(clients) = clients.lock().await.get(&log.process_name[0..index]) {
+            if let Some(clients) = clients
+                .lock()
+                .await
+                .get(&Self::get_program_name(log.process_name.as_str()).unwrap_or(log.process_name))
+            {
                 clients.for_each(Client::send);
             }
         }
@@ -187,107 +198,17 @@ impl Routine {
 
     async fn event_listener(&mut self) {
         while let Some((command, sender)) = self.command_receiver.recv().await {
-            match command {
-                TaskManagerCommand::ListProcesses(list_sender) => {
-                    let vec = self
-                        .processes
-                        .lock()
-                        .await
-                        .iter()
-                        .map(|(name, proceses)| {
-                            proceses
-                                .iter()
-                                .enumerate()
-                                .map(|(i, process)| NominativeStatus {
-                                    process_name: format!("{name}-{i}"),
-                                    status: process.status.clone(),
-                                })
-                                .collect()
-                        })
-                        .collect();
-
-                    list_sender
-                        .send(vec)
-                        .expect("Receiver should never be dropped");
-
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                }
-
-                TaskManagerCommand::StartProgram { program_name } => {
-                    if let Some(program_config) = self.get_program_config(program_name.as_str()) {
-                        self.start_program(&program_config).await;
-                        sender
-                            .send(Ok(()))
-                            .expect("Receiver should never be dropped")
-                    } else {
-                        sender
-                            .send(Err(super::ServerCommandError::NoSuchProgram(program_name)))
-                            .expect("Receiver should never be dropped")
-                    };
-                }
-
-                TaskManagerCommand::RestartProgram { program_name } => {
-                    if let Some(program_config) = self.get_program_config(program_name.as_str()) {
-                        self.stop_program(program_name.as_str()).await;
-                        self.start_program(&program_config).await;
-                        sender
-                            .send(Ok(()))
-                            .expect("Receiver should never be dropped")
-                    } else {
-                        sender
-                            .send(Err(super::ServerCommandError::NoSuchProgram(program_name)))
-                            .expect("Receiver should never be dropped")
-                    };
-                }
-
-                TaskManagerCommand::StopProgram { program_name } => {
-                    self.stop_program(program_name.as_str()).await;
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                }
-
-                TaskManagerCommand::SubscribeToProgramEvents {
-                    program_name,
-                    client,
-                } => {
-                    if let Some(subscribed_clients) = self.clients.lock().await.get(&program_name) {
-                        subscribed_clients.add(client);
-                    }
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                }
-
-                TaskManagerCommand::UnsubscribeToProgramEvents {
-                    program_name,
-                    client,
-                } => {
-                    if let Some(subscribed_clients) = self.clients.lock().await.get(&program_name) {
-                        subscribed_clients.remove(client);
-                    }
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                }
-
-                TaskManagerCommand::StopAllProcesses => {
-                    self.stop_all_processes().await;
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                }
-
-                TaskManagerCommand::Exit => {
-                    self.stop_all_processes().await;
-                    sender
-                        .send(Ok(()))
-                        .expect("Receiver should never be dropped");
-                    break;
-                }
+            if matches!(command, TaskManagerCommand::Exit) {
+                self.stop_all_processes().await;
+                sender
+                    .send(Ok(()))
+                    .expect("Receiver should never be dropped");
+                break;
             }
+
+            sender
+                .send(self.handle_command(command).await)
+                .expect("Receiver should never be dropped");
         }
     }
 
@@ -300,27 +221,6 @@ impl Routine {
         {
             process.stop_and_join_if_running().await;
         }
-    }
-
-    async fn stop_program(&mut self, program_name: &str) {
-        let mut processes = self.processes.lock().await;
-
-        for process in processes
-            .get_mut(program_name)
-            .iter_mut()
-            .flat_map(|process_vec| process_vec.iter_mut())
-        {
-            process.stop_and_join_if_running().await;
-        }
-    }
-
-    fn get_program_config(&self, program_name: &str) -> Option<Arc<ProgramConfig>> {
-        for program in self.program_configs.iter() {
-            if program.name() == program_name {
-                return Some(Arc::clone(program));
-            }
-        }
-        None
     }
 }
 

--- a/taskmaster/src/tasks_manager/tests.rs
+++ b/taskmaster/src/tasks_manager/tests.rs
@@ -1,4 +1,9 @@
-#[cfg(test)]
+use super::routine::Routine;
+use crate::config::Config;
+use crate::tasks_manager::TaskManagerCommand;
+use std::io::Cursor;
+use tokio::sync::oneshot;
+
 fn create_tasks() -> String {
     r#"programs:
     taskmaster_test_task:
@@ -25,23 +30,11 @@ fn create_tasks() -> String {
 
 #[tokio::test]
 async fn task_manager_list_tasks() {
-    use super::routine::Routine;
-    use crate::config::Config;
-    use crate::convert_tasks_to_arc;
-    use crate::tasks_manager::TaskManagerCommand;
-    use std::io::Cursor;
-    use tokio::sync::oneshot;
-
     let yaml_content = create_tasks();
-    let program = Config::from_reader(Cursor::new(yaml_content))
+    let programs_configs = Config::from_reader(Cursor::new(yaml_content))
         .expect("Parse error")
-        .programs
-        .into_iter()
-        .next()
-        .expect("Config vector is empty");
-    let tasks = vec![program];
-    let tasks = convert_tasks_to_arc(tasks);
-    let handle = Routine::spawn(tasks);
+        .programs;
+    let handle = Routine::spawn(programs_configs);
     let (sender, receiver) = oneshot::channel();
     handle
         .send(TaskManagerCommand::ListProcesses(sender))
@@ -53,22 +46,11 @@ async fn task_manager_list_tasks() {
 
 #[tokio::test]
 async fn task_manager_stop() {
-    use super::routine::Routine;
-    use crate::config::Config;
-    use crate::convert_tasks_to_arc;
-    use crate::tasks_manager::TaskManagerCommand;
-    use std::io::Cursor;
-
     let yaml_content = create_tasks();
-    let config = Config::from_reader(Cursor::new(yaml_content))
+    let programs_configs = Config::from_reader(Cursor::new(yaml_content))
         .expect("Parse error")
-        .programs
-        .into_iter()
-        .next()
-        .expect("Config vector is empty");
-    let tasks = vec![config];
-    let tasks = convert_tasks_to_arc(tasks);
-    let handle = Routine::spawn(tasks);
+        .programs;
+    let handle = Routine::spawn(programs_configs);
 
     handle
         .send(TaskManagerCommand::StopProgram {
@@ -81,22 +63,11 @@ async fn task_manager_stop() {
 
 #[tokio::test]
 async fn task_manager_start_already_started() {
-    use super::routine::Routine;
-    use crate::config::Config;
-    use crate::convert_tasks_to_arc;
-    use crate::tasks_manager::TaskManagerCommand;
-    use std::io::Cursor;
-
     let yaml_content = create_tasks();
-    let config = Config::from_reader(Cursor::new(yaml_content))
+    let programs_configs = Config::from_reader(Cursor::new(yaml_content))
         .expect("Parse error")
-        .programs
-        .into_iter()
-        .next()
-        .expect("Config vector is empty");
-    let tasks = vec![config];
-    let tasks = convert_tasks_to_arc(tasks);
-    let handle = Routine::spawn(tasks);
+        .programs;
+    let handle = Routine::spawn(programs_configs);
 
     handle
         .send(TaskManagerCommand::StartProgram {
@@ -108,23 +79,35 @@ async fn task_manager_start_already_started() {
 }
 
 #[tokio::test]
-async fn task_manager_restart() {
-    use super::routine::Routine;
-    use crate::config::Config;
-    use crate::convert_tasks_to_arc;
-    use crate::tasks_manager::TaskManagerCommand;
-    use std::io::Cursor;
-
+async fn task_manager_stop_then_start() {
     let yaml_content = create_tasks();
-    let config = Config::from_reader(Cursor::new(yaml_content))
+    let programs_configs = Config::from_reader(Cursor::new(yaml_content))
         .expect("Parse error")
-        .programs
-        .into_iter()
-        .next()
-        .expect("Config vector is empty");
-    let tasks = vec![config];
-    let arc_tasks = convert_tasks_to_arc(tasks);
-    let handle = Routine::spawn(arc_tasks);
+        .programs;
+    let handle = Routine::spawn(programs_configs);
+
+    handle
+        .send(TaskManagerCommand::StopProgram {
+            program_name: String::from("taskmaster_test_task"),
+        })
+        .await
+        .unwrap();
+    handle
+        .send(TaskManagerCommand::StartProgram {
+            program_name: String::from("taskmaster_test_task"),
+        })
+        .await
+        .unwrap();
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn task_manager_restart() {
+    let yaml_content = create_tasks();
+    let programs_configs = Config::from_reader(Cursor::new(yaml_content))
+        .expect("Parse error")
+        .programs;
+    let handle = Routine::spawn(programs_configs);
 
     handle
         .send(TaskManagerCommand::RestartProgram {


### PR DESCRIPTION
task manager's routine file has changed place and is now cut into two files under task_manager/routine/ one file has been created from the original containing only command handlers