### PR TITLE
feature: now using stop_time parameter

### DIFF
--- a/taskmaster/src/process_handler/routine.rs
+++ b/taskmaster/src/process_handler/routine.rs
@@ -182,9 +182,9 @@ impl Routine {
                 self.kill_command_received = true;
                 Self::kill_subprocess(
                     &mut child,
-                    self.config.stop_signal()
-                );
-                Status::Exited(child.wait().await.expect("error waiting for child"))
+                    self.config.stop_signal(),
+                    self.config.stop_time(),
+                ).await
             }
         };
 
@@ -194,9 +194,23 @@ impl Routine {
         status
     }
 
-    fn kill_subprocess(child: &mut Child, stop_signal: &Signal) {
+    async fn kill_subprocess(child: &mut Child, stop_signal: &Signal, stop_time: &u32) -> Status {
         if let Some(pid) = child.id() {
             unsafe { kill(pid as i32, *stop_signal as i32) };
+        }
+        
+        tokio::select! {
+            status = child.wait() => {
+                Status::Exited(status.expect("error waiting for child after sending stop signal"))
+            }
+            _ = tokio::time::sleep(Duration::from_secs(*stop_time as u64)) => {
+                // sending SIGKILL signal to force a process to stop
+                // SIGKILL cannot be caught by the subprocess and constitutes a way to force processes to stop
+                if let Some(pid) = child.id() {
+                    unsafe { kill(pid as i32, Signal::SIGKILL as i32) };
+                }
+                Status::Exited(child.wait().await.expect("error waiting for child after sending SIGTERM"))
+            }
         }
     }
 

--- a/taskmaster/src/process_handler/routine.rs
+++ b/taskmaster/src/process_handler/routine.rs
@@ -198,7 +198,7 @@ impl Routine {
         if let Some(pid) = child.id() {
             unsafe { kill(pid as i32, *stop_signal as i32) };
         }
-        
+
         tokio::select! {
             status = child.wait() => {
                 Status::Exited(status.expect("error waiting for child after sending stop signal"))

--- a/taskmaster/src/tasks_manager/routine/mod.rs
+++ b/taskmaster/src/tasks_manager/routine/mod.rs
@@ -86,7 +86,7 @@ impl Routine {
     }
 
     async fn start_programs(&mut self) {
-        for (_, program_config) in Arc::clone(&self.program_configs).iter() {
+        for program_config in Arc::clone(&self.program_configs).values() {
             self.start_program(program_config).await;
         }
     }


### PR DESCRIPTION
Using stop_time parameter to wait stop_time secs for the subprocess to stop before shutting it down with uncatchable SIGKILL