### PR TITLE
feat: add dashes to parameter names in config file (#83)

### DIFF
--- a/taskmaster/src/config/deserialize.rs
+++ b/taskmaster/src/config/deserialize.rs
@@ -40,10 +40,10 @@ where
     D: Deserializer<'de>,
 {
     let num_procs = u8::deserialize(deserializer)
-        .map_err(|err| serde::de::Error::custom(format!("Failed to parse numprocs: {err}")))?;
+        .map_err(|err| serde::de::Error::custom(format!("Failed to parse num-procs: {err}")))?;
     if num_procs == 0 {
         Err(serde::de::Error::custom(
-            "Failed to parse numprocs: cannot be 0".to_string(),
+            "Failed to parse num-procs: cannot be 0".to_string(),
         ))
     } else {
         Ok(num_procs)

--- a/taskmaster/src/config/program/mod.rs
+++ b/taskmaster/src/config/program/mod.rs
@@ -17,7 +17,7 @@ use std::{collections::HashMap, fmt::Display, str::FromStr};
 #[allow(dead_code)] // TODO: remove this
 #[derive(Debug, Getters, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ProgramConfig {
     #[serde(skip)]
     name: String,
@@ -31,38 +31,36 @@ pub struct ProgramConfig {
     pub cmd: Command,
 
     #[serde(
-        rename = "numprocs",
         default = "default_num_procs",
         deserialize_with = "deserialize_num_procs"
     )]
     num_procs: u8,
 
-    #[serde(rename = "workingdir", default = "default_work_dir")]
+    #[serde(default = "default_work_dir")]
     working_dir: String,
 
-    #[serde(rename = "autostart", default)]
+    #[serde(default)]
     auto_start: bool,
 
-    #[serde(rename = "autorestart", default)]
+    #[serde(default)]
     auto_restart: AutoRestart,
 
-    #[serde(rename = "exitcodes", default = "default_exit_codes")]
+    #[serde(default = "default_exit_codes")]
     exit_codes: Vec<u8>,
 
-    #[serde(rename = "startretries", default)]
+    #[serde(default)]
     start_retries: u32,
 
-    #[serde(rename = "starttime", default)]
+    #[serde(default)]
     start_time: u32,
 
     #[serde(
-        rename = "stopsignal",
         default = "default_signal",
         deserialize_with = "deserialize_signal"
     )]
     stop_signal: Signal,
 
-    #[serde(rename = "stoptime", default)]
+    #[serde(default)]
     stop_time: u32,
 
     #[serde(default = "default_output")]
@@ -71,7 +69,7 @@ pub struct ProgramConfig {
     #[serde(default = "default_output")]
     stderr: String,
 
-    #[serde(rename = "clearenv", default)]
+    #[serde(default)]
     clear_env: bool,
 
     #[serde(default)]

--- a/taskmaster/src/config/program/tests.rs
+++ b/taskmaster/src/config/program/tests.rs
@@ -224,8 +224,8 @@ mod tests {
             "echo test",
             r#"
             umask: "644"
-            workingdir: "/tmp"
-            autostart: true"#,
+            working-dir: "/tmp"
+            auto-start: true"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -235,7 +235,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            exitcodes: [257]"#,
+            exit-codes: [257]"#,
         );
         assert_config_parsing_error(&yaml_content);
     }
@@ -248,7 +248,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            exitcodes: [0, 1, 2]"#,
+            exit-codes: [0, 1, 2]"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -261,7 +261,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            numprocs: 3"#,
+            num-procs: 3"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -274,7 +274,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            startretries: 5"#,
+            start-retries: 5"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -287,7 +287,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            starttime: 10"#,
+            start-time: 10"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -300,7 +300,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            stoptime: 15"#,
+            stop-time: 15"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -313,7 +313,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            stopsignal: "TERM""#,
+            stop-signal: "TERM""#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -326,7 +326,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            stopsignal: "SIGTERM""#,
+            stop-signal: "SIGTERM""#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -339,7 +339,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            autorestart: true"#,
+            auto-restart: true"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }
@@ -352,7 +352,7 @@ mod tests {
         let yaml_content = yaml_with_fields(
             "echo test",
             r#"
-            clearenv: true"#,
+            clear-env: true"#,
         );
         assert_config_parses_to(&yaml_content, program);
     }

--- a/taskmaster/src/process_handler/routine.rs
+++ b/taskmaster/src/process_handler/routine.rs
@@ -248,7 +248,7 @@ impl Routine {
     ///
     /// - The program started properly:
     ///   - `config.auto_restart` is `false`: Return false (we don't want to restart)
-    ///   - `config.auto_restart` is `unexpected` and the exit status is in `config.exitcodes`: Return false (we don't want to restart)
+    ///   - `config.auto_restart` is `unexpected` and the exit status is in `config.exit-codes`: Return false (we don't want to restart)
     ///   - otherwise return true (we want to restart)
     fn should_try_restart(&mut self, status: &Status) -> bool {
         match status {

--- a/taskmaster/src/process_handler/tests.rs
+++ b/taskmaster/src/process_handler/tests.rs
@@ -74,20 +74,20 @@ async fn create_task() {
     let yaml_content = r#"programs:
     taskmaster_test_task:
         cmd: "bash -c \"echo Hello $STARTED_BY!\""
-        numprocs: 1
+        num-procs: 1
         umask: 022
-        workingdir: /tmp
-        autostart: true
-        exitcodes:
+        working-dir: /tmp
+        auto-start: true
+        exit-codes:
         - 0
         - 2
-        startretries: 5
-        starttime: 0
-        stopsignal: SIGTERM
-        stoptime: 10
+        start-retries: 5
+        start-time: 0
+        stop-signal: SIGTERM
+        stop-time: 10
         stdout: /tmp/taskmaster_tests.stdout
         stderr: /tmp/taskmaster_tests.stderr
-        clearenv: true
+        clear-env: true
         env:
             STARTED_BY: taskmaster
             ANSWER: 42"#;
@@ -159,20 +159,20 @@ async fn create_task_then_interrupt() {
     let yaml_content = r#"programs:
     taskmaster_test_task:
         cmd: "cat"
-        numprocs: 1
+        num-procs: 1
         umask: 022
-        workingdir: /tmp
-        autostart: true
-        exitcodes:
+        working-dir: /tmp
+        auto-start: true
+        exit-codes:
         - 0
         - 2
-        startretries: 5
-        starttime: 0
-        stopsignal: SIGINT
-        stoptime: 10
+        start-retries: 5
+        start-time: 0
+        stop-signal: SIGINT
+        stop-time: 10
         stdout: /tmp/taskmaster_tests_interrupt.stdout
         stderr: /tmp/taskmaster_tests_interrupt.stderr
-        clearenv: true
+        clear-env: true
         env:
             STARTED_BY: taskmaster
             ANSWER: 42"#;

--- a/taskmaster/src/tasks_manager/tests.rs
+++ b/taskmaster/src/tasks_manager/tests.rs
@@ -8,20 +8,20 @@ fn create_tasks() -> String {
     r#"programs:
     taskmaster_test_task:
         cmd: "sleep 100000"
-        numprocs: 2
+        num-procs: 2
         umask: 022
-        workingdir: /tmp
-        autostart: true
-        exitcodes:
+        working-dir: /tmp
+        auto-start: true
+        exit-codes:
         - 0
         - 2
-        startretries: 5
-        starttime: 0
-        stopsignal: SIGTERM
-        stoptime: 10
+        start-retries: 5
+        start-time: 0
+        stop-signal: SIGTERM
+        stop-time: 10
         stdout: /tmp/taskmaster_taskmanager_tests.stdout
         stderr: /tmp/taskmaster_taskmanager_tests.stderr
-        clearenv: true
+        clear-env: true
         env:
             STARTED_BY: taskmaster
             ANSWER: 42"#


### PR DESCRIPTION
## Summary
Updates configuration parameter names in `taskmaster` to use kebab-case (dashed) formatting (fixes #83).

## Parameter Renames
- `autostart` -> `auto-start`
- `numprocs` -> `num-procs`
- `workingdir` -> `working-dir`
- `autorestart` -> `auto-restart`
- `exitcodes` -> `exit-codes`
- `startretries` -> `start-retries`
- `starttime` -> `start-time`
- `stopsignal` -> `stop-signal`
- `stoptime` -> `stop-time`
- `clearenv` -> `clear-env`

## Changes Included
- Added `rename_all = "kebab-case"` to `ProgramConfig` serde deserialization macro.
- Updated `deserialize_num_procs` error messages to reference `num-procs`.
- Updated test YAML snippets across test modules (`config/program/tests.rs`, `process_handler/tests.rs`, `tasks_manager/tests.rs`).